### PR TITLE
Conformer Embedding now embeds for all matches of core in molecule

### DIFF
--- a/src/lib/coaler/core/Matcher.cpp
+++ b/src/lib/coaler/core/Matcher.cpp
@@ -14,7 +14,8 @@
 #include "GraphMol/FMCS/FMCS.h"
 
 namespace coaler::core {
-    std::optional<CoreResult> Matcher::calculateCoreMcs(RDKit::MOL_SPTR_VECT mols) {
+    std::optional<CoreResult> Matcher::calculateCoreMcs(RDKit::MOL_SPTR_VECT mols, int numOfThreads) {
+        // Generates all parameters needed for RDKit::findMCS()
         RDKit::MCSParameters mcsParams;
         RDKit::MCSAtomCompareParameters atomCompParams;
         atomCompParams.MatchChiralTag = true;
@@ -51,7 +52,13 @@ namespace coaler::core {
         std::vector<std::pair<int, double>> result;
         RDKit::MMFF::MMFFOptimizeMoleculeConfs(first, result);
 
-        auto structMatches = RDKit::SubstructMatch(first, *mcs.QueryMol);
+        RDKit::SubstructMatchParameters substructMatchParams;
+        substructMatchParams.useChirality = true;
+        substructMatchParams.useEnhancedStereo = true;
+        substructMatchParams.aromaticMatchesConjugated = true;
+        substructMatchParams.numThreads = numOfThreads;
+
+        std::vector<RDKit::MatchVectType> structMatches = RDKit::SubstructMatch(first, *mcs.QueryMol, substructMatchParams);
         assert(!structMatches.empty());
 
         AtomMap moleculeCoreCoords;
@@ -64,8 +71,8 @@ namespace coaler::core {
         return std::make_pair(mcs.QueryMol, moleculeCoreCoords);
     }
 
-    std::optional<CoreResult> Matcher::calculateCoreMurcko(RDKit::MOL_SPTR_VECT mols) {
-        auto mcs = Matcher::calculateCoreMcs(mols);
+    std::optional<CoreResult> Matcher::calculateCoreMurcko(RDKit::MOL_SPTR_VECT mols, int numOfThreads) {
+        auto mcs = Matcher::calculateCoreMcs(mols, numOfThreads);
         if (!mcs.has_value()) {
             return std::nullopt;
         }

--- a/src/lib/coaler/core/Matcher.cpp
+++ b/src/lib/coaler/core/Matcher.cpp
@@ -58,7 +58,8 @@ namespace coaler::core {
         substructMatchParams.aromaticMatchesConjugated = true;
         substructMatchParams.numThreads = numOfThreads;
 
-        std::vector<RDKit::MatchVectType> structMatches = RDKit::SubstructMatch(first, *mcs.QueryMol, substructMatchParams);
+        std::vector<RDKit::MatchVectType> structMatches
+            = RDKit::SubstructMatch(first, *mcs.QueryMol, substructMatchParams);
         assert(!structMatches.empty());
 
         AtomMap moleculeCoreCoords;

--- a/src/lib/coaler/core/Matcher.hpp
+++ b/src/lib/coaler/core/Matcher.hpp
@@ -16,12 +16,12 @@ namespace coaler::core {
          * calculates the MCS of the molecules
          * @return MCS as ROMol
          */
-        static std::optional<CoreResult> calculateCoreMcs(RDKit::MOL_SPTR_VECT mols);
+        static std::optional<CoreResult> calculateCoreMcs(RDKit::MOL_SPTR_VECT mols, int numOfThreads);
 
         /**
          * calculates the Murcko scaffold of the molecules
          * @return Murcko Scaffold as ROMol
          */
-        static std::optional<CoreResult> calculateCoreMurcko(RDKit::MOL_SPTR_VECT mols);
+        static std::optional<CoreResult> calculateCoreMurcko(RDKit::MOL_SPTR_VECT mols, int numOfThreads);
     };
 }  // namespace coaler::core

--- a/src/lib/coaler/embedder/ConformerEmbedder.cpp
+++ b/src/lib/coaler/embedder/ConformerEmbedder.cpp
@@ -75,8 +75,6 @@ namespace coaler::embedder {
                 RDKit::DGeomHelpers::EmbedMultipleConfs(*mol, numConfs, params);
             }
 
-            spdlog::info("Embedded {} conformers.", mol->getNumConformers());
-
             if ((mol->getNumConformers() == numConfs && m_divideConformersByMatches)
                 || (mol->getNumConformers() == numConfs * nofMatches)) {
                 std::vector<std::pair<int, double>> result;
@@ -89,6 +87,7 @@ namespace coaler::embedder {
             matchCounter++;
         }
 
+        spdlog::info("Embedded {} conformers.", mol->getNumConformers());
         if (m_divideConformersByMatches) {
             assert(mol->getNumConformers() == numConfs);
         } else {

--- a/src/lib/coaler/embedder/ConformerEmbedder.cpp
+++ b/src/lib/coaler/embedder/ConformerEmbedder.cpp
@@ -36,12 +36,10 @@ namespace coaler::embedder {
         substructMatchParams.numThreads = m_threads;
 
         std::vector<RDKit::MatchVectType> matches;
-        unsigned nofMatches = RDKit::SubstructMatch(*mol, *m_core, matches,
-                                                    substructMatchParams.uniquify,
-                                                    substructMatchParams.useChirality,
-                                                    substructMatchParams.useQueryQueryMatches,
-                                                    substructMatchParams.maxMatches,
-                                                    substructMatchParams.numThreads);
+        unsigned nofMatches
+            = RDKit::SubstructMatch(*mol, *m_core, matches, substructMatchParams.uniquify,
+                                    substructMatchParams.useChirality, substructMatchParams.useQueryQueryMatches,
+                                    substructMatchParams.maxMatches, substructMatchParams.numThreads);
         assert(!matches.empty());
 
         spdlog::info("Number of Core Matches: {}", nofMatches);
@@ -70,18 +68,17 @@ namespace coaler::embedder {
 
             // calculates the number of conformers for each match if m_divideConformersByMatches == true
             if (m_divideConformersByMatches) {
-                unsigned nofConfsForMatch = (matchCounter < numConfs % nofMatches) ? (int(numConfs / nofMatches) + 1) :
-                                                                                   (int(numConfs / nofMatches));
+                unsigned nofConfsForMatch = (matchCounter < numConfs % nofMatches) ? (int(numConfs / nofMatches) + 1)
+                                                                                   : (int(numConfs / nofMatches));
                 RDKit::DGeomHelpers::EmbedMultipleConfs(*mol, nofConfsForMatch, params);
-            }
-            else {
+            } else {
                 RDKit::DGeomHelpers::EmbedMultipleConfs(*mol, numConfs, params);
             }
 
             spdlog::info("Embedded {} conformers.", mol->getNumConformers());
 
-            if ((mol->getNumConformers() == numConfs && m_divideConformersByMatches) ||
-                (mol->getNumConformers() == numConfs*nofMatches)) {
+            if ((mol->getNumConformers() == numConfs && m_divideConformersByMatches)
+                || (mol->getNumConformers() == numConfs * nofMatches)) {
                 std::vector<std::pair<int, double>> result;
                 RDKit::MMFF::MMFFOptimizeMoleculeConfs(*mol, result, m_threads);
 
@@ -94,10 +91,8 @@ namespace coaler::embedder {
 
         if (m_divideConformersByMatches) {
             assert(mol->getNumConformers() == numConfs);
-        }
-        else {
+        } else {
             assert(mol->getNumConformers() == numConfs * nofMatches);
         }
-
     }
 }  // namespace coaler::embedder

--- a/src/lib/coaler/embedder/ConformerEmbedder.cpp
+++ b/src/lib/coaler/embedder/ConformerEmbedder.cpp
@@ -19,17 +19,34 @@ const unsigned seed = 42;
 const float forceTol = 0.0135;
 
 namespace coaler::embedder {
-    ConformerEmbedder::ConformerEmbedder(RDKit::ROMOL_SPTR &query, CoreAtomMapping &coords, const int threads)
-        : m_core(query), m_threads(threads), m_coords(coords) {}
+    ConformerEmbedder::ConformerEmbedder(RDKit::ROMOL_SPTR &query, CoreAtomMapping &coords, const int threads,
+                                         const bool divideConformersByMatches)
+        : m_core(query), m_threads(threads), m_coords(coords), m_divideConformersByMatches(divideConformersByMatches) {}
 
     void ConformerEmbedder::embedConformersWithFixedCore(RDKit::ROMOL_SPTR mol, unsigned numConfs) {
         spdlog::info("Embedding {}", RDKit::MolToSmiles(*mol));
         spdlog::info("Pattern {}", RDKit::MolToSmarts(*m_core));
+
         // firstMatch molecule and core
-        RDKit::SubstructMatchParameters matchParams;
-        auto matches = RDKit::SubstructMatch(*mol, *m_core, matchParams);
+        RDKit::SubstructMatchParameters substructMatchParams;
+        substructMatchParams.uniquify = false;
+        substructMatchParams.useChirality = true;
+        substructMatchParams.useQueryQueryMatches = false;
+        substructMatchParams.maxMatches = 1000;
+        substructMatchParams.numThreads = m_threads;
+
+        std::vector<RDKit::MatchVectType> matches;
+        unsigned nofMatches = RDKit::SubstructMatch(*mol, *m_core, matches,
+                                                    substructMatchParams.uniquify,
+                                                    substructMatchParams.useChirality,
+                                                    substructMatchParams.useQueryQueryMatches,
+                                                    substructMatchParams.maxMatches,
+                                                    substructMatchParams.numThreads);
         assert(!matches.empty());
 
+        spdlog::info("Number of Core Matches: {}", nofMatches);
+
+        unsigned matchCounter = 0;
         for (auto const &match : matches) {
             CoreAtomMapping molQueryCoords;
             for (const auto &[queryId, molId] : match) {
@@ -49,11 +66,22 @@ namespace coaler::embedder {
             params.useSmallRingTorsions = false;
             params.useRandomCoords = true;
             params.numThreads = m_threads;
+            params.clearConfs = false;
 
-            RDKit::DGeomHelpers::EmbedMultipleConfs(*mol, numConfs, params);
+            // calculates the number of conformers for each match if m_divideConformersByMatches == true
+            if (m_divideConformersByMatches) {
+                unsigned nofConfsForMatch = (matchCounter < numConfs % nofMatches) ? (int(numConfs / nofMatches) + 1) :
+                                                                                   (int(numConfs / nofMatches));
+                RDKit::DGeomHelpers::EmbedMultipleConfs(*mol, nofConfsForMatch, params);
+            }
+            else {
+                RDKit::DGeomHelpers::EmbedMultipleConfs(*mol, numConfs, params);
+            }
+
             spdlog::info("Embedded {} conformers.", mol->getNumConformers());
 
-            if (mol->getNumConformers() == numConfs) {
+            if ((mol->getNumConformers() == numConfs && m_divideConformersByMatches) ||
+                (mol->getNumConformers() == numConfs*nofMatches)) {
                 std::vector<std::pair<int, double>> result;
                 RDKit::MMFF::MMFFOptimizeMoleculeConfs(*mol, result, m_threads);
 
@@ -61,8 +89,15 @@ namespace coaler::embedder {
 
                 break;
             }
+            matchCounter++;
         }
 
-        assert(mol->getNumConformers() == numConfs);
+        if (m_divideConformersByMatches) {
+            assert(mol->getNumConformers() == numConfs);
+        }
+        else {
+            assert(mol->getNumConformers() == numConfs * nofMatches);
+        }
+
     }
 }  // namespace coaler::embedder

--- a/src/lib/coaler/embedder/ConformerEmbedder.hpp
+++ b/src/lib/coaler/embedder/ConformerEmbedder.hpp
@@ -12,17 +12,22 @@ namespace coaler::embedder {
 
     class ConformerEmbedder {
       public:
-        // ConformerEmbedder(const RDKit::ROMol& core,
-        //                   unsigned numCoreConfigs);
 
-        explicit ConformerEmbedder(RDKit::ROMOL_SPTR& query, CoreAtomMapping& coords, int threads = 1);
+        explicit ConformerEmbedder(RDKit::ROMOL_SPTR& query, CoreAtomMapping& coords, int threads = 1,
+                                   bool divideConformersByMatches = false);
 
+        /***
+         * embedding of the molecules with their respective number of Conformers
+         * @param mol
+         * @param numConfs
+         */
         void embedConformersWithFixedCore(RDKit::ROMOL_SPTR mol, unsigned numConfs);
 
       private:
         RDKit::ROMOL_SPTR m_core;
         CoreAtomMapping m_coords;
         int m_threads;
+        bool m_divideConformersByMatches;
 
         std::vector<RDKit::MatchVectType> filterMatches(const std::vector<RDKit::MatchVectType>& matches);
     };

--- a/src/lib/coaler/embedder/ConformerEmbedder.hpp
+++ b/src/lib/coaler/embedder/ConformerEmbedder.hpp
@@ -12,7 +12,6 @@ namespace coaler::embedder {
 
     class ConformerEmbedder {
       public:
-
         explicit ConformerEmbedder(RDKit::ROMOL_SPTR& query, CoreAtomMapping& coords, int threads = 1,
                                    bool divideConformersByMatches = false);
 

--- a/src/lib/coaler/multialign/MultiAligner.cpp
+++ b/src/lib/coaler/multialign/MultiAligner.cpp
@@ -101,7 +101,7 @@ namespace coaler::multialign {
                 omp_init_lock(&maplock);
 
 #pragma omp parallel for shared(maplock, ligands, scores, nofPosesFirst, nofPosesSecond, firstMolId, \
-                                    secondMolId) default(none)
+                                secondMolId) default(none)
                 for (unsigned firstMolPoseId = 0; firstMolPoseId < nofPosesFirst; firstMolPoseId++) {
                     for (unsigned secondMolPoseId = 0; secondMolPoseId < nofPosesSecond; secondMolPoseId++) {
                         RDKit::RWMol const firstMol = ligands.at(firstMolId).getMolecule();
@@ -182,7 +182,7 @@ namespace coaler::multialign {
         omp_init_lock(&bestAssemblyLock);
 
 #pragma omp parallel for shared(bestAssemblyScoreLock, bestAssemblyLock, currentBestAssembly, \
-                                    currentBestAssemblyScore, assembliesList) default(none)
+                                currentBestAssemblyScore, assembliesList) default(none)
         for (unsigned assemblyID = 0; assemblyID < assembliesList.size(); assemblyID++) {
             auto [currentAssembly, currentAssemblyScore] = assembliesList.at(assemblyID);
             spdlog::debug("Score before opt: {}", currentAssemblyScore);

--- a/src/lib/coaler/multialign/MultiAligner.cpp
+++ b/src/lib/coaler/multialign/MultiAligner.cpp
@@ -88,8 +88,13 @@ namespace coaler::multialign {
     PairwiseAlignment MultiAligner::calculateAlignmentScores(const LigandVector &ligands) {
         PairwiseAlignment scores;
         unsigned n = ligands.size();
-        unsigned m = ligands.at(0).getNumPoses();
-        unsigned combinations = 0.5 * n * (n - 1) * m * m;  // TODO how many?
+        unsigned combinations = 0;
+        for (unsigned id_A = 0; id_A < n; id_A++) {
+            for (unsigned id_B = id_A+1; id_B < n; id_B++) {
+                combinations += ligands.at(id_A).getNumPoses() * ligands.at(id_B).getNumPoses();
+            }
+        }
+
         spdlog::info("Calculating {} combinations. This may take some time", combinations);
 
         for (LigandID firstMolId = 0; firstMolId < ligands.size(); firstMolId++) {

--- a/src/lib/coaler/multialign/MultiAligner.cpp
+++ b/src/lib/coaler/multialign/MultiAligner.cpp
@@ -87,6 +87,9 @@ namespace coaler::multialign {
 
     PairwiseAlignment MultiAligner::calculateAlignmentScores(const LigandVector &ligands) {
         PairwiseAlignment scores;
+
+        // calculate number of combinations. Each pair of ligands A,B has
+        // A.getNumPoses() * B.getNumPoses() many embeddings
         unsigned n = ligands.size();
         unsigned combinations = 0;
         for (unsigned id_A = 0; id_A < n; id_A++) {

--- a/src/lib/coaler/multialign/MultiAligner.cpp
+++ b/src/lib/coaler/multialign/MultiAligner.cpp
@@ -93,7 +93,7 @@ namespace coaler::multialign {
         unsigned n = ligands.size();
         unsigned combinations = 0;
         for (unsigned id_A = 0; id_A < n; id_A++) {
-            for (unsigned id_B = id_A+1; id_B < n; id_B++) {
+            for (unsigned id_B = id_A + 1; id_B < n; id_B++) {
                 combinations += ligands.at(id_A).getNumPoses() * ligands.at(id_B).getNumPoses();
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,8 +34,10 @@ const std::string help
       "  -f, --files <path>\t\t\tPath to input files\n"
       "  -o, --out <path>\t\t\tPath to output files\n"
       "  -j, --threads <amount>\t\t\tNumber of threads to use (default: 1)\n"
-      "  --conformers <amount>\t\t\tNumber of conformers per core match to generate for each input molecule (default: 10)\n"
-      "  --divide <bool>\t\t\tDivide the number of conformers by the number of times the core is matched in the input molecule. "
+      "  --conformers <amount>\t\t\tNumber of conformers per core match to generate for each input molecule (default: "
+      "10)\n"
+      "  --divide <bool>\t\t\tDivide the number of conformers by the number of times the core is matched in the input "
+      "molecule. "
       "Helps against combinatorial explosion if core is small or has high symmetry (default: false)\n"
       "  --assemblies <amount>\t\t\tNumber of starting assemblies (default: 10)\n"
       "  --core <algorithm>\t\t\tAlgorithm to detect core structure (default: mcs, allowed: mcs, murcko)\n";
@@ -51,9 +53,9 @@ std::optional<ProgrammOptions> parseArgs(int argc, char* argv[]) {
         "assemblies, a", opts::value<unsigned>(&parsed_options.num_start_assemblies)->default_value(10),
         "number of starting assemblies to use")(
         "core", opts::value<std::string>(&parsed_options.core_type)->default_value("mcs"),
-        "algo to detect core structure")(
-        "conformers,c", opts::value<unsigned>(&parsed_options.num_conformers)->default_value(10),
-        "number of conformers per core match to generate")(
+        "algo to detect core structure")("conformers,c",
+                                         opts::value<unsigned>(&parsed_options.num_conformers)->default_value(10),
+                                         "number of conformers per core match to generate")(
         "divide,d", opts::value<bool>(&parsed_options.divideConformersByMatches)->default_value(false),
         "divides the number of conformers by the number of times the core is matched");
 
@@ -110,11 +112,11 @@ int main(int argc, char* argv[]) {
 
     spdlog::info("embedding {} conformers each into molecules", opts.num_conformers);
 
-    embedder::ConformerEmbedder embedder(coreResult->first, coreResult->second, opts.num_threads, opts.divideConformersByMatches);
+    embedder::ConformerEmbedder embedder(coreResult->first, coreResult->second, opts.num_threads,
+                                         opts.divideConformersByMatches);
     for (auto& mol : mols) {
         embedder.embedConformersWithFixedCore(mol, opts.num_conformers);
     }
-
 
     multialign::MultiAligner aligner(mols, opts.num_start_assemblies, opts.num_threads);
     auto result = aligner.alignMolecules();

--- a/test/test_core.cpp
+++ b/test/test_core.cpp
@@ -16,7 +16,7 @@ TEST_CASE("Core_constructor", "[core]") {
     mols.emplace_back(mol1);
     mols.emplace_back(mol2);
 
-    auto coreScaffoldMCS = Matcher::calculateCoreMcs(mols);
+    auto coreScaffoldMCS = Matcher::calculateCoreMcs(mols, 1);
     CHECK(RDKit::MolToSmarts(*coreScaffoldMCS.value().first)
           == "[#6]1:&@[#6]:&@[#6](:&@[#6]:&@[#6]:&@[#6]:&@1)-&!@[#7&R]");
 


### PR DESCRIPTION
Added new flags: 
    --assemblies: number of starting assemblies can now be configured
    --divide: bool if the number of conformers per mol shall be divided by the number of matches of core found in mol