### PR TITLE
added conformer log

### DIFF
--- a/src/lib/coaler/io/OutputWriter.cpp
+++ b/src/lib/coaler/io/OutputWriter.cpp
@@ -9,9 +9,27 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <spdlog/spdlog.h>
 
+namespace {
+    std::string get_formatted_string(unsigned num, unsigned digits) {
+        unsigned num_digits = std::to_string(num).length();
+        std::string result;
+        while (result.size() < digits - num_digits) {
+            result += "0";
+        }
+        result += std::to_string(num);
+        return result;
+    }
+}  // namespace
+
+/*----------------------------------------------------------------------------------------------------------------*/
+
 namespace coaler::io {
 
     void OutputWriter::writeSDF(const std::string &file_path, const coaler::multialign::MultiAlignerResult &result) {
+        if (result.inputLigands.size() != result.poseIDsByLigandID.size()) {
+            throw std::runtime_error(fmt::format("received less output molecules than there was in input: {}/{}",
+                                                 result.poseIDsByLigandID.size(), result.inputLigands.size()));
+        }
         std::ofstream output_file(file_path);
         if (!output_file.is_open()) {
             spdlog::error("Cannot open file: {}", file_path);
@@ -22,6 +40,33 @@ namespace coaler::io {
         for (const auto &[ligand_id, pose_id] : result.poseIDsByLigandID) {
             auto entry = result.inputLigands.at(ligand_id);
             sdf_writer->write(entry.getMolecule(), pose_id);
+        }
+    }
+
+    /*----------------------------------------------------------------------------------------------------------------*/
+
+    void OutputWriter::writeConformersToSDF(const std::string &folder_path,
+                                            const std::vector<RDKit::ROMOL_SPTR> &mols) {
+        std::string file_path = folder_path;
+        if (file_path.back() != '/') {
+            file_path += "/";
+        }
+        unsigned magnitude = std::to_string(mols.size()).length();
+        for (unsigned molId = 0; molId < mols.size(); molId++) {
+            auto mol = mols.at(molId);
+
+            std::string currentFilePath = file_path + "mol_" + get_formatted_string(molId, magnitude) + ".sdf";
+            std::ofstream output_file(currentFilePath);
+
+            if (!output_file.is_open()) {
+                spdlog::error("Cannot open file: {}", folder_path);
+                return;
+            }
+
+            boost::shared_ptr<RDKit::SDWriter> const sdf_writer(new RDKit::SDWriter(&output_file, false));
+            for (unsigned conformerId = 0; conformerId < mol->getNumConformers(); conformerId++) {
+                sdf_writer->write(*mol, conformerId);
+            }
         }
     }
 }  // namespace coaler::io

--- a/src/lib/coaler/io/OutputWriter.hpp
+++ b/src/lib/coaler/io/OutputWriter.hpp
@@ -21,7 +21,14 @@ namespace coaler::io {
          * Writes the aligned molecules in an output file.
          * @param file_path
          */
-        static void writeSDF(const std::string &file_path, const coaler::multialign::MultiAlignerResult &result);
+        static void writeSDF(const std::string& file_path, const coaler::multialign::MultiAlignerResult& result);
+
+        /**
+         * Writes all conformers of a molecule to a sdf file.
+         * @param folder_path A path to the folder store the files in
+         * @param mol A molecule whose conformers are to be written to an .sdf file
+         */
+        static void writeConformersToSDF(const std::string& folder_path, const std::vector<RDKit::ROMOL_SPTR>& mols);
     };
 
 }  // namespace coaler::io

--- a/src/lib/coaler/multialign/MultiAligner.cpp
+++ b/src/lib/coaler/multialign/MultiAligner.cpp
@@ -109,7 +109,7 @@ namespace coaler::multialign {
                 omp_init_lock(&maplock);
 
 #pragma omp parallel for shared(maplock, ligands, scores, nofPosesFirst, nofPosesSecond, firstMolId, \
-                                secondMolId) default(none)
+                                    secondMolId) default(none)
                 for (unsigned firstMolPoseId = 0; firstMolPoseId < nofPosesFirst; firstMolPoseId++) {
                     for (unsigned secondMolPoseId = 0; secondMolPoseId < nofPosesSecond; secondMolPoseId++) {
                         RDKit::RWMol const firstMol = ligands.at(firstMolId).getMolecule();
@@ -190,7 +190,7 @@ namespace coaler::multialign {
         omp_init_lock(&bestAssemblyLock);
 
 #pragma omp parallel for shared(bestAssemblyScoreLock, bestAssemblyLock, currentBestAssembly, \
-                                currentBestAssemblyScore, assembliesList) default(none)
+                                    currentBestAssemblyScore, assembliesList) default(none)
         for (unsigned assemblyID = 0; assemblyID < assembliesList.size(); assemblyID++) {
             auto [currentAssembly, currentAssemblyScore] = assembliesList.at(assemblyID);
             spdlog::debug("Score before opt: {}", currentAssemblyScore);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@ const std::string help
     = "Usage: aligner [options]\n"
       "Options:\n"
       "  -h, --help\t\t\t\tPrint this help message\n"
-      "  -f, --files <path>\t\t\tPath to input files\n"
+      "  -i, --input_file <path>\t\t\tPath to input files\n"
       "  -o, --out <path>\t\t\tPath to output files\n"
       "  -j, --threads <amount>\t\t\tNumber of threads to use (default: 1)\n"
       "  --conformers <amount>\t\t\tNumber of conformers per core match to generate for each input molecule (default: "
@@ -49,7 +49,7 @@ std::optional<ProgrammOptions> parseArgs(int argc, char* argv[]) {
 
     opts::options_description desc("Allowed options");
     desc.add_options()("help,h", "print help message")(
-        "file,i", opts::value<std::string>(&parsed_options.input_file_path)->required(), "path to input file")(
+        "input_file,i", opts::value<std::string>(&parsed_options.input_file_path)->required(), "path to input file")(
         "out,o", opts::value<std::string>(&parsed_options.out_file)->default_value("out.sdf"), "path to output file")(
         "threads,j", opts::value<int>(&parsed_options.num_threads)->default_value(1), "number of threads to use")(
         "assemblies, a", opts::value<unsigned>(&parsed_options.num_start_assemblies)->default_value(10),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@ struct ProgrammOptions {
     unsigned num_start_assemblies;
     std::string core_type;
     bool divideConformersByMatches;
+    std::string conformerLogPath;
 };
 
 const std::string help
@@ -40,14 +41,15 @@ const std::string help
       "molecule. "
       "Helps against combinatorial explosion if core is small or has high symmetry (default: false)\n"
       "  --assemblies <amount>\t\t\tNumber of starting assemblies (default: 10)\n"
-      "  --core <algorithm>\t\t\tAlgorithm to detect core structure (default: mcs, allowed: mcs, murcko)\n";
+      "  --core <algorithm>\t\t\tAlgorithm to detect core structure (default: mcs, allowed: mcs, murcko)\n"
+      "  --confsLog <path>\t\t\tOptional path to folder to store the generated conformers\n";
 
 std::optional<ProgrammOptions> parseArgs(int argc, char* argv[]) {
     ProgrammOptions parsed_options;
 
     opts::options_description desc("Allowed options");
     desc.add_options()("help,h", "print help message")(
-        "file,f", opts::value<std::string>(&parsed_options.input_file_path)->required(), "path to input file")(
+        "file,i", opts::value<std::string>(&parsed_options.input_file_path)->required(), "path to input file")(
         "out,o", opts::value<std::string>(&parsed_options.out_file)->default_value("out.sdf"), "path to output file")(
         "threads,j", opts::value<int>(&parsed_options.num_threads)->default_value(1), "number of threads to use")(
         "assemblies, a", opts::value<unsigned>(&parsed_options.num_start_assemblies)->default_value(10),
@@ -57,7 +59,8 @@ std::optional<ProgrammOptions> parseArgs(int argc, char* argv[]) {
                                          opts::value<unsigned>(&parsed_options.num_conformers)->default_value(10),
                                          "number of conformers per core match to generate")(
         "divide,d", opts::value<bool>(&parsed_options.divideConformersByMatches)->default_value(false),
-        "divides the number of conformers by the number of times the core is matched");
+        "divides the number of conformers by the number of times the core is matched")(
+        "confsLog", opts::value<std::string>(&parsed_options.conformerLogPath)->default_value("none"));
 
     opts::variables_map vm;
     opts::store(opts::parse_command_line(argc, argv, desc), vm);
@@ -114,8 +117,12 @@ int main(int argc, char* argv[]) {
 
     embedder::ConformerEmbedder embedder(coreResult->first, coreResult->second, opts.num_threads,
                                          opts.divideConformersByMatches);
+
     for (auto& mol : mols) {
         embedder.embedConformersWithFixedCore(mol, opts.num_conformers);
+    }
+    if (opts.conformerLogPath != "none") {
+        coaler::io::OutputWriter::writeConformersToSDF(opts.conformerLogPath, mols);
     }
 
     multialign::MultiAligner aligner(mols, opts.num_start_assemblies, opts.num_threads);


### PR DESCRIPTION
 the log saves the generated conformers of each mol in a seperate file.

- the arg is optional so you wont spam you pc with sdf file
- note that unless you change the --consfLog argument (provides a destination folder), the sdf files will be overwritten 

- also changed arg -f to -i for sanity reasons