### PR TITLE
Fix incomplete results

### DIFF
--- a/src/lib/coaler/multialign/Forward.hpp
+++ b/src/lib/coaler/multialign/Forward.hpp
@@ -16,7 +16,11 @@ namespace coaler::multialign {
     namespace Constants {
         constexpr unsigned DEFAULT_NOF_STARTING_ASSEMBLIES = 50;
         constexpr unsigned DEFAULT_NOF_THREADS = 1;
+        constexpr double POSE_REGISTER_SIZE_FACTOR = 0.5;
     }  // namespace Constants
+
+    static_assert(Constants::POSE_REGISTER_SIZE_FACTOR < 1);
+    static_assert(Constants::POSE_REGISTER_SIZE_FACTOR > 0);
 
     class PoseRegister;
     using PoseRegisterPtr = std::shared_ptr<PoseRegister>;

--- a/src/lib/coaler/multialign/MultiAligner.cpp
+++ b/src/lib/coaler/multialign/MultiAligner.cpp
@@ -109,7 +109,7 @@ namespace coaler::multialign {
                 omp_init_lock(&maplock);
 
 #pragma omp parallel for shared(maplock, ligands, scores, nofPosesFirst, nofPosesSecond, firstMolId, \
-                                secondMolId) default(none)
+                                    secondMolId) default(none)
                 for (unsigned firstMolPoseId = 0; firstMolPoseId < nofPosesFirst; firstMolPoseId++) {
                     for (unsigned secondMolPoseId = 0; secondMolPoseId < nofPosesSecond; secondMolPoseId++) {
                         RDKit::RWMol const firstMol = ligands.at(firstMolId).getMolecule();
@@ -190,7 +190,7 @@ namespace coaler::multialign {
         omp_init_lock(&bestAssemblyLock);
 
 #pragma omp parallel for shared(bestAssemblyScoreLock, bestAssemblyLock, currentBestAssembly, \
-                                currentBestAssemblyScore, assembliesList) default(none)
+                                    currentBestAssemblyScore, assembliesList) default(none)
         for (unsigned assemblyID = 0; assemblyID < assembliesList.size(); assemblyID++) {
             auto [currentAssembly, currentAssemblyScore] = assembliesList.at(assemblyID);
             spdlog::debug("Score before opt: {}", currentAssemblyScore);

--- a/src/lib/coaler/multialign/PoseRegisterBuilder.cpp
+++ b/src/lib/coaler/multialign/PoseRegisterBuilder.cpp
@@ -48,7 +48,7 @@ namespace coaler::multialign {
 
     unsigned PoseRegisterBuilder::calculateRegisterSizeForLigand(const Ligand &firstLigand,
                                                                  const Ligand &secondLigand) {
-        //return 2* (firstLigand.getNumHeavyAtoms() + secondLigand.getNumHeavyAtoms());  // TODO find appropriate value
+        // return 2* (firstLigand.getNumHeavyAtoms() + secondLigand.getNumHeavyAtoms());  // TODO find appropriate value
         double size = Constants::POSE_REGISTER_SIZE_FACTOR * firstLigand.getNumPoses() * secondLigand.getNumPoses();
         return static_cast<unsigned>(size);
     }

--- a/src/lib/coaler/multialign/PoseRegisterBuilder.cpp
+++ b/src/lib/coaler/multialign/PoseRegisterBuilder.cpp
@@ -48,7 +48,8 @@ namespace coaler::multialign {
 
     unsigned PoseRegisterBuilder::calculateRegisterSizeForLigand(const Ligand &firstLigand,
                                                                  const Ligand &secondLigand) {
-        return firstLigand.getNumHeavyAtoms() + secondLigand.getNumHeavyAtoms();  // TODO find appropriate value
-        // return sqrt(firstLigand.getNumHeavyAtoms() + secondLigand.getNumHeavyAtoms());
+        //return 2* (firstLigand.getNumHeavyAtoms() + secondLigand.getNumHeavyAtoms());  // TODO find appropriate value
+        double size = Constants::POSE_REGISTER_SIZE_FACTOR * firstLigand.getNumPoses() * secondLigand.getNumPoses();
+        return static_cast<unsigned>(size);
     }
 }  // namespace coaler::multialign


### PR DESCRIPTION
- made pose register size depend on number of conformers instead of number of heavy atoms
- implemented constant to control pose register size to handle

We should consider undoing this change once dynamic conformer adaption is in place.