### PR TITLE
Rework pose register

### DIFF
--- a/src/lib/coaler/multialign/PoseRegister.cpp
+++ b/src/lib/coaler/multialign/PoseRegister.cpp
@@ -16,10 +16,11 @@ namespace {
 namespace coaler::multialign {
 
     PoseRegister::PoseRegister(LigandID firstLigand, LigandID secondLigand, unsigned maxSize)
-        : m_maxSize(maxSize), m_first(firstLigand), m_second(secondLigand),
-          m_lowest(std::make_pair(PosePair({0,1},{0,0}), std::numeric_limits<double>::max())),
-          m_highest(std::make_pair(PosePair({0,1},{0,0}), std::numeric_limits<double>::min()))
-    {
+        : m_maxSize(maxSize),
+          m_first(firstLigand),
+          m_second(secondLigand),
+          m_lowest(std::make_pair(PosePair({0, 1}, {0, 0}), std::numeric_limits<double>::max())),
+          m_highest(std::make_pair(PosePair({0, 1}, {0, 0}), std::numeric_limits<double>::min())) {
         assert(m_first != m_second);
     }
 
@@ -82,7 +83,7 @@ namespace coaler::multialign {
 
     /*----------------------------------------------------------------------------------------------------------------*/
 
-    void PoseRegister::updateHighest(const PosePairAndScore& insertedPair) {
+    void PoseRegister::updateHighest(const PosePairAndScore &insertedPair) {
         if (insertedPair.second > m_highest.second) {
             m_highest = insertedPair;
         }
@@ -94,19 +95,17 @@ namespace coaler::multialign {
         assert(m_register.size() == m_maxSize + 1);
         auto itemToRemove = m_register.begin();
         auto newLowest = m_register.begin();
-        for(auto iter = m_register.begin(); iter != m_register.end(); iter++) {
-            if(iter->second < itemToRemove->second){
+        for (auto iter = m_register.begin(); iter != m_register.end(); iter++) {
+            if (iter->second < itemToRemove->second) {
                 newLowest = itemToRemove;
                 itemToRemove = iter;
-            }
-            else if(iter->second < newLowest->second) {
+            } else if (iter->second < newLowest->second) {
                 newLowest = iter;
             }
         }
         m_register.erase(itemToRemove);
         m_lowest = *newLowest;
         assert(m_register.size() == m_maxSize);
-
     }
 
 }  // namespace coaler::multialign

--- a/src/lib/coaler/multialign/PoseRegister.cpp
+++ b/src/lib/coaler/multialign/PoseRegister.cpp
@@ -16,7 +16,10 @@ namespace {
 namespace coaler::multialign {
 
     PoseRegister::PoseRegister(LigandID firstLigand, LigandID secondLigand, unsigned maxSize)
-        : m_maxSize(maxSize), m_first(firstLigand), m_second(secondLigand) {
+        : m_maxSize(maxSize), m_first(firstLigand), m_second(secondLigand),
+          m_lowest(std::make_pair(PosePair({0,1},{0,0}), std::numeric_limits<double>::max())),
+          m_highest(std::make_pair(PosePair({0,1},{0,0}), std::numeric_limits<double>::min()))
+    {
         assert(m_first != m_second);
     }
 
@@ -33,17 +36,19 @@ namespace coaler::multialign {
     void PoseRegister::addPoses(const PosePair pair, const double score) {
         if (m_register.size() < m_maxSize) {
             m_register.emplace_back(pair, score);
-            std::sort(m_register.begin(), m_register.end(), PosePairScoreGreater());
-        } else if (score > m_register.back().second) {
-            m_register.pop_back();
+            PosePairAndScore insertedElement = m_register.back();
+            updateHighest(insertedElement);
+            updateLowest();
+        } else if (score > m_lowest.second) {
             m_register.emplace_back(pair, score);
-            std::sort(m_register.begin(), m_register.end(), PosePairScoreGreater());
+            updateHighest(m_register.back());
+            removeAndUpdateLowest();
         }
     }
 
     /*----------------------------------------------------------------------------------------------------------------*/
 
-    PosePair PoseRegister::getHighestScoringPair() { return m_register.at(0).first; }
+    PosePair PoseRegister::getHighestScoringPair() { return m_highest.first; }
 
     /*----------------------------------------------------------------------------------------------------------------*/
 
@@ -66,6 +71,42 @@ namespace coaler::multialign {
             }
         }
         return currentBest.first;
+    }
+
+    /*----------------------------------------------------------------------------------------------------------------*/
+
+    void PoseRegister::updateLowest() {
+        auto lowest = std::min_element(m_register.begin(), m_register.end(), PosePairScoreGreater());
+        m_lowest = *lowest;
+    }
+
+    /*----------------------------------------------------------------------------------------------------------------*/
+
+    void PoseRegister::updateHighest(const PosePairAndScore& insertedPair) {
+        if (insertedPair.second > m_highest.second) {
+            m_highest = insertedPair;
+        }
+    }
+
+    /*----------------------------------------------------------------------------------------------------------------*/
+
+    void PoseRegister::removeAndUpdateLowest() {
+        assert(m_register.size() == m_maxSize + 1);
+        auto itemToRemove = m_register.begin();
+        auto newLowest = m_register.begin();
+        for(auto iter = m_register.begin(); iter != m_register.end(); iter++) {
+            if(iter->second < itemToRemove->second){
+                newLowest = itemToRemove;
+                itemToRemove = iter;
+            }
+            else if(iter->second < newLowest->second) {
+                newLowest = iter;
+            }
+        }
+        m_register.erase(itemToRemove);
+        m_lowest = *newLowest;
+        assert(m_register.size() == m_maxSize);
+
     }
 
 }  // namespace coaler::multialign

--- a/src/lib/coaler/multialign/PoseRegister.hpp
+++ b/src/lib/coaler/multialign/PoseRegister.hpp
@@ -61,10 +61,17 @@ namespace coaler::multialign {
         bool containsPose(const UniquePoseID& pose);
 
       private:
+
+        void updateLowest();
+        void removeAndUpdateLowest();
+        void updateHighest(const PosePairAndScore& insertedPair);
+
         LigandID m_first;
         LigandID m_second;
         unsigned m_maxSize;
         std::vector<PosePairAndScore> m_register;
+        PosePairAndScore m_lowest;
+        PosePairAndScore m_highest;
     };
 
 }  // namespace coaler::multialign

--- a/src/lib/coaler/multialign/PoseRegister.hpp
+++ b/src/lib/coaler/multialign/PoseRegister.hpp
@@ -61,7 +61,6 @@ namespace coaler::multialign {
         bool containsPose(const UniquePoseID& pose);
 
       private:
-
         void updateLowest();
         void removeAndUpdateLowest();
         void updateHighest(const PosePairAndScore& insertedPair);

--- a/test/test_pose_register.cpp
+++ b/test/test_pose_register.cpp
@@ -3,7 +3,7 @@
 #include "coaler/multialign/PoseRegister.hpp"
 
 TEST_CASE("test_add_poses_to_register", "[multialign]") {
-    coaler::multialign::PoseRegister poseRegister(1, 2, 3);
+    coaler::multialign::PoseRegister poseRegister(1, 2, 2);
     coaler::multialign::PosePair pair1({0, 0}, {1, 0});
     coaler::multialign::PosePair pair2({0, 0}, {2, 0});
     coaler::multialign::PosePair pair3({1, 0}, {2, 0});
@@ -16,7 +16,10 @@ TEST_CASE("test_add_poses_to_register", "[multialign]") {
     CHECK(poseRegister.getHighestScoringPair() == pair2);
     poseRegister.addPoses(pair3, 1.0);
     CHECK(poseRegister.getHighestScoringPair() == pair2);
-    CHECK(poseRegister.getSize() == 3);
+    CHECK(poseRegister.getSize() == 2);
+    poseRegister.addPoses(pair3, 3.0);
+    CHECK(poseRegister.getHighestScoringPair() == pair3);
+    CHECK(poseRegister.getSize() == 2);
 }
 
 TEST_CASE("test_add_pose_to_full_register", "[multialign]") {

--- a/test/test_pose_register_builder.cpp
+++ b/test/test_pose_register_builder.cpp
@@ -10,27 +10,27 @@ using namespace coaler::multialign;
 
 TEST_CASE("test_pose_register_builder", "[multialign]") {
     PairwiseAlignment pairwiseScores;
-    UniquePoseID m0p0(0, 0);
-    UniquePoseID m0p1(0, 1);
-    UniquePoseID m1p0(1, 0);
-    UniquePoseID m1p1(1, 1);
-    Ligand l1(*RDKit::SmilesToMol("CN"), {m0p0, m0p1}, 0);
-    Ligand l2(*RDKit::SmilesToMol("CO"), {m1p0, m1p1}, 1);
-    LigandPair ligandPair(l1.getID(), l2.getID());
-    PosePair m0p0m1p0(m0p0, m1p0);
-    PosePair m0p0m1p1(m0p0, m1p1);
-    PosePair m0p1m1p0(m0p1, m1p0);
-    PosePair m0p1m1p1(m0p1, m1p1);
+    const UniquePoseID m0p0(0, 0);
+    const UniquePoseID m0p1(0, 1);
+    const UniquePoseID m1p0(1, 0);
+    const UniquePoseID m1p1(1, 1);
+    const Ligand l1(*RDKit::SmilesToMol("CN"), {m0p0, m0p1}, 0);
+    const Ligand l2(*RDKit::SmilesToMol("CO"), {m1p0, m1p1}, 1);
+    const LigandPair ligandPair(l1.getID(), l2.getID());
+    const PosePair m0p0m1p0(m0p0, m1p0);
+    const PosePair m0p0m1p1(m0p0, m1p1);
+    const PosePair m0p1m1p0(m0p1, m1p0);
+    const PosePair m0p1m1p1(m0p1, m1p1);
     pairwiseScores.emplace(m0p0m1p0, 0.8);
     pairwiseScores.emplace(m0p1m1p0, 0.5);
     pairwiseScores.emplace(m0p0m1p1, 0.1);
     pairwiseScores.emplace(m0p1m1p1, 0.3);
 
-    PoseRegisterCollection collection = PoseRegisterBuilder::buildPoseRegisters(pairwiseScores, {l1, l2});
+    const PoseRegisterCollection collection = PoseRegisterBuilder::buildPoseRegisters(pairwiseScores, {l1, l2});
 
     PairwisePoseRegisters reg = collection.getAllRegisters();
 
     CHECK(reg.size() == 1);
-    CHECK(reg.at(ligandPair)->getSize() == 4);
+    CHECK(reg.at(ligandPair)->getSize() == Constants::POSE_REGISTER_SIZE_FACTOR * l1.getNumPoses() * l2.getNumPoses());
     CHECK(reg.at(ligandPair)->getHighestScoringPair() == m0p0m1p0);
 }


### PR DESCRIPTION
before, after adding a pose, the entire register was sorted. For registers of ~10^5 elements, doing this over and over again was slow. now the adding of a pose happens in linear time