### PR TITLE
Opt embedder precheck

### DIFF
--- a/src/lib/coaler/embedder/ConformerEmbedder.cpp
+++ b/src/lib/coaler/embedder/ConformerEmbedder.cpp
@@ -239,8 +239,8 @@ namespace coaler::embedder {
         RDKit::MatchVectType targetMatch;
 
         // get atom coords for core structure
-        const CoreAtomMapping coreCoords
-            = getLigandMcsAtomCoordsFromTargetMatch(m_core.ref->getConformer(0).getPositions(), ligandMatch, targetMatch);
+        const CoreAtomMapping coreCoords = getLigandMcsAtomCoordsFromTargetMatch(
+            m_core.ref->getConformer(0).getPositions(), ligandMatch, targetMatch);
         params.coordMap = &coreCoords;
         params.numThreads = m_threads;
 

--- a/src/lib/coaler/embedder/ConformerEmbedder.cpp
+++ b/src/lib/coaler/embedder/ConformerEmbedder.cpp
@@ -13,7 +13,7 @@
 
 const unsigned SEED = 42;
 const float FORCE_TOL = 0.0135;
-const unsigned BRUTEFORCE_CONFS = 100;
+const unsigned BRUTEFORCE_CONFS = 500;
 
 namespace {
     RDKit::SubstructMatchParameters get_optimizer_substruct_params() {
@@ -229,7 +229,7 @@ namespace coaler::embedder {
     /*----------------------------------------------------------------------------------------------------------------*/
 
     std::vector<multialign::PoseID> ConformerEmbedder::generateNewPosesForAssemblyLigand(
-        const multialign::Ligand &worstLigand, const core::CoreResult &core) {
+        const multialign::Ligand &worstLigand) {
         std::vector<unsigned> newIds;
         std::vector<int> newIntIds;
         auto *ligandMol = (RDKit::ROMol *)worstLigand.getMoleculePtr();
@@ -240,8 +240,9 @@ namespace coaler::embedder {
 
         // get atom coords for core structure
         const CoreAtomMapping coreCoords
-            = getLigandMcsAtomCoordsFromTargetMatch(core.ref->getConformer(0).getPositions(), ligandMatch, targetMatch);
+            = getLigandMcsAtomCoordsFromTargetMatch(m_core.ref->getConformer(0).getPositions(), ligandMatch, targetMatch);
         params.coordMap = &coreCoords;
+        params.numThreads = m_threads;
 
         // embed BRUTEFORCE_CONFS new conformers into ligand
         try {

--- a/src/lib/coaler/embedder/ConformerEmbedder.cpp
+++ b/src/lib/coaler/embedder/ConformerEmbedder.cpp
@@ -173,8 +173,11 @@ namespace coaler::embedder {
             RDKit::DGeomHelpers::EmbedParameters params = get_embed_params_for_optimizer_generation();
             int addedID = -1;
 
+            double relaxedMcsSizeFactor = ligandMatchRelaxed.size() / ligandMol->getNumAtoms();
+            double strictMcsSizeFactor = ligandMatchStrict.size() / ligandMol->getNumAtoms();
+
             // try relaxed mcs first
-            if (!ligandMatchRelaxed.empty() && !targetMatchRelaxed.empty()) {
+            if (!ligandMatchRelaxed.empty() && !targetMatchRelaxed.empty() && relaxedMcsSizeFactor > 0.2) {
                 spdlog::debug("trying relaxed substructure approach.");
                 ligandMcsCoords = getLigandMcsAtomCoordsFromTargetMatch(targetConformer.getPositions(),
                                                                         ligandMatchRelaxed, targetMatchRelaxed);
@@ -192,7 +195,7 @@ namespace coaler::embedder {
             }
 
             // if relaxed mcs params didnt yield valid embedding, reattempt with strict mcs.
-            if (addedID < 0 && !ligandMatchStrict.empty() && !targetMatchStrict.empty()) {
+            if (addedID < 0 && !ligandMatchStrict.empty() && !targetMatchStrict.empty() && strictMcsSizeFactor > 0.2) {
                 spdlog::debug("flexible approach failed. Trying strict approach.");
                 ligandMcsCoords = getLigandMcsAtomCoordsFromTargetMatch(targetConformer.getPositions(),
                                                                         ligandMatchStrict, targetMatchStrict);

--- a/src/lib/coaler/embedder/ConformerEmbedder.hpp
+++ b/src/lib/coaler/embedder/ConformerEmbedder.hpp
@@ -18,7 +18,7 @@ namespace coaler::embedder {
      */
     class ConformerEmbedder {
       public:
-        ConformerEmbedder(core::CoreResult result, int threads, bool divideConformersByMatches);
+        ConformerEmbedder(core::CoreResult result, int threads, bool divideConformersByMatches = true);
 
         /**
          * Embed an even amount of conformers at every core match.
@@ -57,8 +57,7 @@ namespace coaler::embedder {
          * @param core core structure of all molecules
          * @return IDs of conformers added to @param worstLigand
          */
-        static std::vector<multialign::PoseID> generateNewPosesForAssemblyLigand(const multialign::Ligand& worstLigand,
-                                                                                 const core::CoreResult& core);
+        std::vector<multialign::PoseID> generateNewPosesForAssemblyLigand(const multialign::Ligand& worstLigand);
 
         static CoreAtomMapping getLigandMcsAtomCoordsFromTargetMatch(const RDGeom::POINT3D_VECT& targetCoords,
                                                                      const RDKit::MatchVectType& ligandMcsMatch,

--- a/src/lib/coaler/embedder/ConformerEmbedder.hpp
+++ b/src/lib/coaler/embedder/ConformerEmbedder.hpp
@@ -46,7 +46,8 @@ namespace coaler::embedder {
         static std::vector<multialign::PoseID> generateNewPosesForAssemblyLigand(
             const multialign::Ligand& worstLigand, const multialign::LigandVector& targets,
             const std::unordered_map<multialign::LigandID, multialign::PoseID>& conformerIDs,
-            const core::PairwiseMCSMap& pairwiseStrictMCSMap, const core::PairwiseMCSMap& pairwiseRelaxedMCSMap);
+            const core::PairwiseMCSMap& pairwiseStrictMCSMap, const core::PairwiseMCSMap& pairwiseRelaxedMCSMap,
+            bool enforceGeneration = false);
 
         /**
          * @overload

--- a/src/lib/coaler/multialign/AssemblyOptimizer.cpp
+++ b/src/lib/coaler/multialign/AssemblyOptimizer.cpp
@@ -196,8 +196,9 @@ OptimizerState AssemblyOptimizer::optimizeAssembly(LigandAlignmentAssembly assem
             break;
         }
 
-        if(worstLigandId == std::numeric_limits<LigandID>::max()) {
-            spdlog::error("Unable to generate feasible conformers using mcs method. Resorting to bruteforce conformer "
+        if (worstLigandId == std::numeric_limits<LigandID>::max()) {
+            spdlog::error(
+                "Unable to generate feasible conformers using mcs method. Resorting to bruteforce conformer "
                 "sampling");
             break;
         }
@@ -237,7 +238,8 @@ OptimizerState AssemblyOptimizer::optimizeAssembly(LigandAlignmentAssembly assem
             assert(alignmentTargets.size() == ligands.size() - 1);
 
             auto newConfIDs = coaler::embedder::ConformerEmbedder::generateNewPosesForAssemblyLigand(
-                *worstLigand, alignmentTargets, assembly.getAssemblyMapping(), m_strictMCSMap, m_relaxedMCSMap, ligandIsMissing);
+                *worstLigand, alignmentTargets, assembly.getAssemblyMapping(), m_strictMCSMap, m_relaxedMCSMap,
+                ligandIsMissing);
 
             if (newConfIDs.empty()) {
                 spdlog::warn("no confs generated. skipping ligand {}", RDKit::MolToSmiles(worstLigand->getMolecule()));
@@ -353,8 +355,7 @@ void AssemblyOptimizer::fixWorstLigands(LigandAlignmentAssembly assembly, Pairwi
             LigandAlignmentAssembly assemblyCopy = assembly;
 
             // generate new conformers for ligand with fixed core coords
-            const std::vector<multialign::PoseID> newPoseIDs =
-                embedder.generateNewPosesForAssemblyLigand(ligand);
+            const std::vector<multialign::PoseID> newPoseIDs = embedder.generateNewPosesForAssemblyLigand(ligand);
             if (newPoseIDs.empty()) {
                 spdlog::warn("bruteforce: no confs generated. skipping ligand {}",
                              RDKit::MolToSmiles(ligand.getMolecule()));
@@ -368,7 +369,7 @@ void AssemblyOptimizer::fixWorstLigands(LigandAlignmentAssembly assembly, Pairwi
                 = find_optimal_pose(ligandID, newPoseIDs, assemblyCopy, scores, ligands);
 
             spdlog::info("bruteforce: best assembly score found with bruteforce: {}, current assembly score {}.",
-                          bestNewAssemblyScore, assemblyScore);
+                         bestNewAssemblyScore, assemblyScore);
 
             RDKit::ROMol mol = ligand.getMolecule();
             RDKit::ROMOL_SPTR molSPTR = boost::make_shared<RDKit::ROMol>(mol);

--- a/src/lib/coaler/multialign/AssemblyOptimizer.cpp
+++ b/src/lib/coaler/multialign/AssemblyOptimizer.cpp
@@ -194,6 +194,12 @@ OptimizerState AssemblyOptimizer::optimizeAssembly(LigandAlignmentAssembly assem
             break;
         }
 
+        if(worstLigandId == std::numeric_limits<LigandID>::max()) {
+            spdlog::error("Unable to generate feasible conformers using mcs method. Resorting to bruteforce conformer "
+                "sampling");
+            break;
+        }
+
         Ligand *worstLigand = &ligands.at(worstLigandId);
         bool ligandIsMissing = (maxScoreDeficit == -1);
         bool swappedLigandPose = false;

--- a/src/lib/coaler/multialign/AssemblyOptimizer.cpp
+++ b/src/lib/coaler/multialign/AssemblyOptimizer.cpp
@@ -368,13 +368,6 @@ void AssemblyOptimizer::fixWorstLigands(LigandAlignmentAssembly assembly, Pairwi
             spdlog::debug("bruteforce: best assembly score found with bruteforce: {}, current assembly score {}.",
                           bestNewAssemblyScore, assemblyScore);
 
-            RDKit::ROMol mol = ligand.getMolecule();
-            RDKit::ROMOL_SPTR molSPTR = boost::make_shared<RDKit::ROMol>(mol);
-            std::vector<RDKit::ROMOL_SPTR> molVec;
-            molVec.push_back(molSPTR);
-            spdlog::info("ligand: {}.", RDKit::MolToSmiles(mol));
-            io::OutputWriter::writeConformersToSDF("/tmp/confs", molVec);
-
             // add new pose to assembly if new bruteforce score is higher than old score
             if (bestNewAssemblyScore > assemblyScore) {
                 assemblyScore = bestNewAssemblyScore;

--- a/src/lib/coaler/multialign/AssemblyOptimizer.cpp
+++ b/src/lib/coaler/multialign/AssemblyOptimizer.cpp
@@ -235,7 +235,7 @@ OptimizerState AssemblyOptimizer::optimizeAssembly(LigandAlignmentAssembly assem
             assert(alignmentTargets.size() == ligands.size() - 1);
 
             auto newConfIDs = coaler::embedder::ConformerEmbedder::generateNewPosesForAssemblyLigand(
-                *worstLigand, alignmentTargets, assembly.getAssemblyMapping(), m_strictMCSMap, m_relaxedMCSMap);
+                *worstLigand, alignmentTargets, assembly.getAssemblyMapping(), m_strictMCSMap, m_relaxedMCSMap, ligandIsMissing);
 
             if (newConfIDs.empty()) {
                 spdlog::warn("no confs generated. skipping ligand {}", RDKit::MolToSmiles(worstLigand->getMolecule()));
@@ -342,7 +342,7 @@ void AssemblyOptimizer::fixWorstLigands(LigandAlignmentAssembly assembly, Pairwi
         LigandID ligandID = ligand.getID();
         const double currScore = ligandScores.at(ligandID);
         if (currScore + SCORE_THRESHOLD * currScore < ligandScoreMean) {
-            spdlog::debug(
+            spdlog::info(
                 "bruteforce: found ligand {} with below average alignment score. Starting bruteforce conformer "
                 "generation.",
                 RDKit::MolToSmiles(ligand.getMolecule()));

--- a/src/lib/coaler/multialign/AssemblyOptimizer.hpp
+++ b/src/lib/coaler/multialign/AssemblyOptimizer.hpp
@@ -53,7 +53,7 @@ namespace coaler::multialign {
          * @param registers The registers for all ligand pairs
          * @param core core of all input molecules
          */
-        static void fixWorstLigands(LigandAlignmentAssembly assembly, PairwiseAlignments scores, LigandVector ligands,
+        void fixWorstLigands(LigandAlignmentAssembly assembly, PairwiseAlignments scores, LigandVector ligands,
                                     PoseRegisterCollection registers, const core::CoreResult& core);
 
         int m_threads;

--- a/src/lib/coaler/multialign/AssemblyOptimizer.hpp
+++ b/src/lib/coaler/multialign/AssemblyOptimizer.hpp
@@ -54,7 +54,7 @@ namespace coaler::multialign {
          * @param core core of all input molecules
          */
         void fixWorstLigands(LigandAlignmentAssembly assembly, PairwiseAlignments scores, LigandVector ligands,
-                                    PoseRegisterCollection registers, const core::CoreResult& core);
+                             PoseRegisterCollection registers, const core::CoreResult& core);
 
         int m_threads;
         int m_stepLimit;

--- a/src/lib/coaler/multialign/Constants.hpp
+++ b/src/lib/coaler/multialign/Constants.hpp
@@ -9,13 +9,13 @@ namespace coaler::multialign::constants {
      * This treshold determines the score deficit above which new conformers are attempted to be generated
      * during assembly optimization.
      */
-    const double COARSE_OPTIMIZATION_THRESHOLD = 1.0;
+    const double COARSE_OPTIMIZATION_THRESHOLD = 1.5;
 
     /**
      * This treshold determines the score deficit above which new conformers are attempted to be generated
      * during the fine tuning of the best alignment assembly.
      */
-    const double FINE_OPTIMIZATION_THRESHOLD = 0.05;
+    const double FINE_OPTIMIZATION_THRESHOLD = 0.1;
 
     const unsigned OPTIMIZER_STEP_LIMIT = 100;
 }  // namespace coaler::multialign::constants

--- a/src/lib/coaler/multialign/MultiAligner.cpp
+++ b/src/lib/coaler/multialign/MultiAligner.cpp
@@ -159,7 +159,7 @@ namespace coaler::multialign {
         OptimizerState bestAssembly{-1, {}, {}, {}, {}};
 
 #pragma omp parallel for shared(bestAssembly, bestAssemblyLock, skippedAssembliesCount, skippedAssembliesCountLock, \
-                                assembliesList) default(none)
+                                    assembliesList) default(none)
         for (unsigned assemblyID = 0; assemblyID < assembliesList.size(); assemblyID++) {
             spdlog::debug("assembly {} has mapped Conformers for {}/{} molecules.", assemblyID,
                           assembliesList.at(assemblyID).first.getAssemblyMapping().size(), m_ligands.size());

--- a/src/lib/coaler/multialign/MultiAligner.cpp
+++ b/src/lib/coaler/multialign/MultiAligner.cpp
@@ -159,8 +159,7 @@ namespace coaler::multialign {
         OptimizerState bestAssembly{-1, {}, {}, {}, {}};
 
 #pragma omp parallel for shared(bestAssembly, bestAssemblyLock, skippedAssembliesCount, skippedAssembliesCountLock, \
-                                    assembliesList) default(none)
-
+                                assembliesList) default(none)
         for (unsigned assemblyID = 0; assemblyID < assembliesList.size(); assemblyID++) {
             spdlog::debug("assembly {} has mapped Conformers for {}/{} molecules.", assemblyID,
                           assembliesList.at(assemblyID).first.getAssemblyMapping().size(), m_ligands.size());

--- a/test/data/2zsd.smi
+++ b/test/data/2zsd.smi
@@ -1,0 +1,12 @@
+[H]C1=C([H])C([H])=C(C(F)(F)F)C(C(=O)N([H])[C@]([H])(C2=NN=C(SC([H])([H])C([H])([H])OC3=C(C([H])([H])[H])C([H])=C([H])C([H])=C3[H])N2C([H])([H])[H])C([H])([H])[H])=C1[H]	ZVV_A_501
+[H]O[C@@]1([H])[C@@]([H])(O[H])[C@]([H])(N2C3=NC([H])=NC(N([H])[H])=C3/N=C\2[H])O[C@]1([H])C([H])([H])O[P@](=O)(O[H])OP(=O)(O[H])O[H]	ADP_A_800
+[H]C1=C([H])C([H])=C(C(=O)N([H])[C@]([H])(C2=NN=C(SC([H])([H])C([H])([H])OC3=C([H])C([H])=C(F)C([H])=C3[H])N2C([H])([H])[H])C([H])([H])[H])C(Cl)=C1[H]	ZVT_A_501
+[H]O[C@@]1([H])[C@@]([H])(O[H])[C@]([H])(N2C3=NC([H])=NC(N([H])[H])=C3/N=C\2[H])O[C@]1([H])C([H])([H])O[P@](=O)(O[H])O[P@](=O)(O[H])C([H])([H])P(=O)(O[H])O[H]	ACP_A_500
+[H]OC([H])([H])C([H])([H])SSC([H])([H])C([H])([H])N([H])C(=O)C([H])([H])C([H])([H])N([H])C(=O)[C@]([H])(O[H])C(C([H])([H])[H])(C([H])([H])[H])C([H])([H])O[P@](=O)(O[H])O[P@](=O)(O[H])OC([H])([H])[C@@]1([H])O[C@@]([H])(N2C([H])=NC3=C2N=C([H])N=C3N([H])[H])[C@]([H])(O[H])[C@]1([H])OP(=O)(O[H])O[H]	COK_A_401
+[H]OC(=O)C([H])([H])OC1=C([H])C([H])=C(C2=C([H])C([H])=C(C#N)C([H])=C2[H])C(C([H])([H])N2C([H])([H])C([H])([H])N(C3=C([H])C([H])=C([H])C([H])=N3)C([H])([H])C2([H])[H])=C1[H]	ZVY_A_501
+[H]C1=C([H])C([H])=C([H])C(N2C([H])([H])C([H])([H])N(C([H])([H])C3=C([H])C(OC([H])([H])C(=O)N([H])C([H])([H])[H])=C([H])C([H])=C3C3=C([H])C([H])=C(C#N)C([H])=C3[H])C([H])([H])C2([H])[H])=N1	ZVZ_A_501
+[H]O[C@@]1([H])[C@@]([H])(O[H])[C@]([H])(N2C3=C(/N=C\2[H])C(=O)N([H])C(N([H])[H])=N3)O[C@]1([H])C([H])([H])O[P@](=O)(O[H])O[P@@](=O)(O[H])C([H])([H])P(=O)(O[H])O[H]	GCP_A_313
+[H]C1=C([H])C([H])=C(C(F)(F)F)C(C(=O)N([H])[C@]([H])(C2=NN=C(SC([H])([H])C3=C([H])C([H])=C(F)C([H])=C3[H])N2C([H])([H])[H])C([H])([H])[H])=C1[H]	ZVU_A_501
+[H]O[C@]1([H])[C@]([H])(OP(=O)(O[H])O[H])[C@@]([H])(C([H])([H])O[P@@](=O)(O[H])O[P@@](=O)(O[H])OC([H])([H])C(C([H])([H])[H])(C([H])([H])[H])[C@@]([H])(O[H])C(=O)N([H])C([H])([H])C([H])([H])C(=O)N([H])C([H])([H])C([H])([H])S[H])O[C@@]1([H])N1C([H])=NC2=C(N([H])[H])N=C([H])N=C21	COA_A_650
+[H]O[C@@]1([H])[C@@]([H])(O[H])[C@]([H])(N2C3=C(/N=C\2[H])C(=O)N([H])C(N([H])[H])=N3)O[C@]1([H])C([H])([H])O[P@@](=O)(O[H])OP(=O)(O[H])O[H]	GDP_A_313
+[H]C1=C([H])C(C(=O)N([H])[C@]([H])(C2=NN=C(SC([H])([H])C([H])([H])OC3=C([H])C([H])=C(F)C([H])=C3[H])N2C([H])([H])C2=C([H])C([H])=C(F)C([H])=C2[H])C([H])([H])[H])=C(C(F)(F)F)C([H])=C1[H]	ZVW_A_501


### PR DESCRIPTION
avoid unnessecary embeddings for the case that pairwise mcs is very small in comparison to mol size. Will fall back to bruteforcing if nessecary